### PR TITLE
Article page

### DIFF
--- a/src/components/Article/index.js
+++ b/src/components/Article/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { PrismicRichText } from "@prismicio/react";
-import { H1, P, MarginContainer } from "../../styles/styles";
+import { H1, H2, H3, P, MarginContainer } from "../../styles/styles";
 import { ArticleContainer, Section, StyledP, StyledImage } from "./styled";
 
 const Article = ({
@@ -20,13 +20,15 @@ const Article = ({
         </Section>
         <Section>
           <StyledImage src={imageUrl} alt={imageAlt} />
-          <P>{imageCaption} </P>
+          <P>{imageCaption}</P>
         </Section>
         <Section>
           <PrismicRichText
             field={content}
             components={{
               paragraph: ({ children }) => <StyledP>{children}</StyledP>,
+              heading2: ({ children }) => <H2>{children}</H2>,
+              heading3: ({ children }) => <H3>{children}</H3>,
             }}
           />
         </Section>

--- a/src/components/Article/index.js
+++ b/src/components/Article/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { PrismicRichText } from "@prismicio/react";
 import { H1, P, MarginContainer } from "../../styles/styles";
-import { ArticleContainer, Section, StyledP } from "./styled";
+import { ArticleContainer, Section, StyledP, StyledImage } from "./styled";
 
 const Article = ({
   title,
@@ -10,8 +10,6 @@ const Article = ({
   imageUrl,
   imageAlt,
   imageCaption,
-  secondaryImageUrl,
-  secondaryImageAlt,
 }) => {
   return (
     <MarginContainer>
@@ -21,14 +19,13 @@ const Article = ({
           <P>{author}</P>
         </Section>
         <Section>
-          <img src={imageUrl} alt={imageAlt} width="100%" />
+          <StyledImage src={imageUrl} alt={imageAlt} />
           <P>{imageCaption} </P>
         </Section>
         <Section>
           <StyledP>
             <PrismicRichText field={content} />
           </StyledP>
-          <img src={secondaryImageUrl} alt={secondaryImageAlt} />
         </Section>
       </ArticleContainer>
     </MarginContainer>

--- a/src/components/Article/index.js
+++ b/src/components/Article/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { PrismicRichText } from "@prismicio/react";
 import { H1, P, MarginContainer } from "../../styles/styles";
+import { ArticleContainer, Section, StyledP } from "./styled";
 
 const Article = ({
   title,
@@ -14,12 +15,22 @@ const Article = ({
 }) => {
   return (
     <MarginContainer>
-      <H1>{title}</H1>
-      <P>{author}</P>
-      <img src={imageUrl} alt={imageAlt} />
-      <P>{imageCaption} </P>
-      <PrismicRichText field={content} />
-      <img src={secondaryImageUrl} alt={secondaryImageAlt} />
+      <ArticleContainer>
+        <Section>
+          <H1>{title}</H1>
+          <P>{author}</P>
+        </Section>
+        <Section>
+          <img src={imageUrl} alt={imageAlt} width="100%" />
+          <P>{imageCaption} </P>
+        </Section>
+        <Section>
+          <StyledP>
+            <PrismicRichText field={content} />
+          </StyledP>
+          <img src={secondaryImageUrl} alt={secondaryImageAlt} />
+        </Section>
+      </ArticleContainer>
     </MarginContainer>
   );
 };

--- a/src/components/Article/index.js
+++ b/src/components/Article/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { PrismicRichText } from "@prismicio/react";
+import { H1, P, MarginContainer } from "../../styles/styles";
+
+const Article = ({
+  title,
+  content,
+  author,
+  imageUrl,
+  imageAlt,
+  imageCaption,
+  secondaryImageUrl,
+  secondaryImageAlt,
+}) => {
+  return (
+    <MarginContainer>
+      <H1>{title}</H1>
+      <P>{author}</P>
+      <img src={imageUrl} alt={imageAlt} />
+      <P>{imageCaption} </P>
+      <PrismicRichText field={content} />
+      <img src={secondaryImageUrl} alt={secondaryImageAlt} />
+    </MarginContainer>
+  );
+};
+
+export default Article;

--- a/src/components/Article/index.js
+++ b/src/components/Article/index.js
@@ -23,9 +23,12 @@ const Article = ({
           <P>{imageCaption} </P>
         </Section>
         <Section>
-          <StyledP>
-            <PrismicRichText field={content} />
-          </StyledP>
+          <PrismicRichText
+            field={content}
+            components={{
+              paragraph: ({ children }) => <StyledP>{children}</StyledP>,
+            }}
+          />
         </Section>
       </ArticleContainer>
     </MarginContainer>

--- a/src/components/Article/styled.js
+++ b/src/components/Article/styled.js
@@ -19,3 +19,7 @@ export const StyledP = styled(P)`
   width: 100%;
   margin-block: 0;
 `;
+
+export const StyledImage = styled.img`
+  width: 100%;
+`;

--- a/src/components/Article/styled.js
+++ b/src/components/Article/styled.js
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import { BLUE, MarginContainer, P, H2, H3 } from "../../styles/styles";
+import { min } from "../../styles/breakpoints";
+
+export const ArticleContainer = styled.div`
+  width: 100%;
+  ${min.desktop} {
+    width: 66.66%;
+    margin-left: 16.66%;
+  }
+`;
+
+export const Section = styled.div`
+  margin-bottom: 3rem;
+`;
+
+export const StyledP = styled(P)`
+  display: inline-block;
+  width: 100%;
+  margin-block: 0;
+`;

--- a/src/components/Article/styled.js
+++ b/src/components/Article/styled.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { BLUE, MarginContainer, P, H2, H3 } from "../../styles/styles";
+import { P } from "../../styles/styles";
 import { min } from "../../styles/breakpoints";
 
 export const ArticleContainer = styled.div`

--- a/src/pages/works/{PrismicArticle.uid}.js
+++ b/src/pages/works/{PrismicArticle.uid}.js
@@ -13,7 +13,6 @@ const ArticlePage = ({ data }) => {
         author: { text: author },
         image: { url: imageUrl, alt: imageAlt },
         image_caption: { text: imageCaption },
-        secondary_image: { url: secondaryImageUrl, alt: secondaryImageAlt },
       },
     },
   } = data;
@@ -27,8 +26,6 @@ const ArticlePage = ({ data }) => {
         imageUrl={imageUrl}
         imageAlt={imageAlt}
         imageCaption={imageCaption}
-        secondaryImageUrl={secondaryImageUrl}
-        secondaryImageAlt={secondaryImageAlt}
       />
     </Layout>
   );
@@ -50,10 +47,6 @@ export const articleQuery = graphql`
         }
         image_caption {
           text
-        }
-        secondary_image {
-          url
-          alt
         }
         title {
           text

--- a/src/pages/works/{PrismicArticle.uid}.js
+++ b/src/pages/works/{PrismicArticle.uid}.js
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { graphql } from "gatsby";
-import parse from "html-react-parser";
 import Layout from "../../components/Layout";
-import { PrismicRichText } from "@prismicio/react";
+import Article from "../../components/Article";
 
 const ArticlePage = ({ data }) => {
   if (!data) return null;
@@ -21,7 +20,16 @@ const ArticlePage = ({ data }) => {
 
   return (
     <Layout>
-      <h1>{title.text}</h1>
+      <Article
+        title={title}
+        content={articleContent}
+        author={author}
+        imageUrl={imageUrl}
+        imageAlt={imageAlt}
+        imageCaption={imageCaption}
+        secondaryImageUrl={secondaryImageUrl}
+        secondaryImageAlt={secondaryImageAlt}
+      />
     </Layout>
   );
 };

--- a/src/pages/works/{PrismicArticle.uid}.js
+++ b/src/pages/works/{PrismicArticle.uid}.js
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { graphql } from "gatsby";
+import parse from "html-react-parser";
+import Layout from "../../components/Layout";
+import { PrismicRichText } from "@prismicio/react";
+
+const ArticlePage = ({ data }) => {
+  if (!data) return null;
+  const {
+    prismicArticle: {
+      data: {
+        title: { text: title },
+        article_content: { richText: articleContent },
+        author: { text: author },
+        image: { url: imageUrl, alt: imageAlt },
+        image_caption: { text: imageCaption },
+        secondary_image: { url: secondaryImageUrl, alt: secondaryImageAlt },
+      },
+    },
+  } = data;
+
+  return (
+    <Layout>
+      <h1>{title.text}</h1>
+    </Layout>
+  );
+};
+
+export const articleQuery = graphql`
+  query ArticlePageQuery($uid: String) {
+    prismicArticle(uid: { eq: $uid }) {
+      data {
+        article_content {
+          richText
+        }
+        author {
+          text
+        }
+        image {
+          url
+          alt
+        }
+        image_caption {
+          text
+        }
+        secondary_image {
+          url
+          alt
+        }
+        title {
+          text
+        }
+      }
+    }
+  }
+`;
+
+export default ArticlePage;


### PR DESCRIPTION
Notes:
 - In order to see this page I made a temporary test article page in prismic which can be viewed at http://localhost:8000/works/testarticle when running locally
 - For the second image in the article page wireframes (at the bottom), I figured this image might be part of the rich text, so the content section currently allows images so the client will be able to add as many or as little secondary images as they like, although I'm not sure how much control we'll have over the styling of them in this case. If this is not the case I can change the prismic type to include a separate secondary image section

![image](https://user-images.githubusercontent.com/72950143/166337274-95e752e8-146a-46a8-9d19-ef2398c19a2d.png)

![image](https://user-images.githubusercontent.com/72950143/166337292-6187e948-c0d5-43aa-a608-0030ca5e94f7.png)

![image](https://user-images.githubusercontent.com/72950143/166337304-56e9b743-80d7-4f17-8d60-675ff92aac70.png)

