### PR TITLE
Gallery page

### DIFF
--- a/src/components/ArrowControls/index.js
+++ b/src/components/ArrowControls/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { ArrowLeft, ArrowRight } from 'react-feather';
+import { Controls, Arrow } from './styled';
+
+/**
+ * modulo function that works with negative divisors
+ */
+const mod = (a, b) => ((a % b) + b) % b;
+
+const ArrowControls = ({ setIndex, items }) => {
+  const tabNext = () => {
+    setIndex((i) => mod(i + 1, items.length));
+  };
+
+  const tabPrev = () => {
+    setIndex((i) => mod(i - 1, items.length));
+  };
+
+  return (
+    <Controls>
+      <Arrow onClick={tabPrev}>
+        <ArrowLeft />
+      </Arrow>
+      <Arrow onClick={tabNext}>
+        <ArrowRight />
+      </Arrow>
+    </Controls>
+  );
+};
+
+export default ArrowControls;

--- a/src/components/ArrowControls/styled.js
+++ b/src/components/ArrowControls/styled.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import { YELLOW } from '../../styles/styles';
+
+export const Controls = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem 0;
+`;
+
+export const Arrow = styled.button`
+  border: 0;
+  background-color: transparent;
+  color: ${YELLOW};
+  padding: 0;
+`;

--- a/src/components/Button/styled.js
+++ b/src/components/Button/styled.js
@@ -1,6 +1,12 @@
 import styled, { css } from 'styled-components';
-import { H1, H3, YELLOW, BLACK, CREAM } from '../../styles/styles';
-import Cursor from '../../images/cursor-pointer.svg';
+import {
+  H1,
+  H3,
+  YELLOW,
+  BLACK,
+  CREAM,
+  PointerStyles,
+} from '../../styles/styles';
 
 const primaryStyles = css`
   padding: 0.5rem 1.5rem;
@@ -29,7 +35,7 @@ const secondaryStyles = css`
 
 export const StyledButton = styled.button`
   ${(props) => (props.secondary ? secondaryStyles : primaryStyles)}
-  cursor: url(${Cursor}) 20 20, pointer;
+  ${PointerStyles}
 `;
 
 // offsets the skew from transforming the button
@@ -37,7 +43,7 @@ const textStyles = css`
   ${(props) => !props.secondary && 'transform: skew(-15deg);'}
   margin-block-start: 0;
   margin-block-end: 0;
-  cursor: url(${Cursor}) 20 20, pointer;
+  ${PointerStyles}
 `;
 
 export const ButtonText = styled(H3)`

--- a/src/components/Gallery/index.js
+++ b/src/components/Gallery/index.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { H1, StyledLink, H3 } from '../../styles/styles';
+import {
+  Container,
+  InfoContainer,
+  ProjectName,
+  DetailsContainer,
+  Details,
+  Description,
+  ImageContainer,
+  Image,
+  Thumbnails,
+  Thumbnail,
+} from './styled';
+import ArrowControls from '../ArrowControls';
+
+const Gallery = ({
+  title,
+  project,
+  artistName,
+  datePublished,
+  description,
+  images,
+}) => {
+  const [index, setIndex] = useState(0);
+  const {
+    uid,
+    data: {
+      name: { text: projectName },
+    },
+  } = project;
+
+  return (
+    <Container>
+      <InfoContainer>
+        <H1>{title}</H1>
+        <StyledLink to={`/projects/${uid}`}>
+          <ProjectName>{projectName}</ProjectName>
+        </StyledLink>
+        <DetailsContainer>
+          <Details>
+            <H3>{artistName}</H3>
+            <H3>{datePublished}</H3>
+          </Details>
+          <Description>{description}</Description>
+        </DetailsContainer>
+      </InfoContainer>
+      <ImageContainer>
+        <Image src={images[index].image.url} alt={images[index].image.url} />
+        <ArrowControls setIndex={setIndex} items={images} />
+      </ImageContainer>
+      <Thumbnails>
+        {images.map((image, i) => (
+          <Thumbnail
+            key={i}
+            src={image.image.url}
+            alt={image.image.alt}
+            onClick={() => setIndex(i)}
+          />
+        ))}
+      </Thumbnails>
+    </Container>
+  );
+};
+
+export default Gallery;

--- a/src/components/Gallery/styled.js
+++ b/src/components/Gallery/styled.js
@@ -1,0 +1,96 @@
+import styled from 'styled-components';
+import { min } from '../../styles/breakpoints';
+import {
+  MarginContainer,
+  YELLOW,
+  BLUE,
+  P,
+  PointerStyles,
+  H2,
+} from '../../styles/styles';
+
+export const Container = styled(MarginContainer)`
+  display: grid;
+  ${min.desktop} {
+    grid-template-columns: 5fr 7fr;
+    column-gap: 1rem;
+  }
+`;
+
+export const InfoContainer = styled.div`
+  ${min.desktop} {
+    grid-column: 1 / 2;
+  }
+`;
+
+export const ProjectName = styled(H2)`
+  display: inline-block;
+  margin-block: 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid transparent;
+  &:hover {
+    border-bottom: 2px solid ${BLUE};
+  }
+`;
+
+export const DetailsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  ${min.tablet} {
+    flex-direction: row;
+  }
+  ${min.desktop} {
+    flex-direction: column;
+  }
+`;
+
+export const Details = styled.div`
+  flex: 1 0 25%;
+`;
+
+export const Description = styled(P)`
+  ${min.desktop} {
+    width: 80%;
+  }
+`;
+
+export const ImageContainer = styled.div`
+  width: 100%;
+  ${min.desktop} {
+    grid-column: 2 / 3;
+    grid-row: 1 / 3;
+  }
+`;
+
+export const Image = styled.img`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  ${min.desktop} {
+    margin-top: 4rem;
+  }
+`;
+
+export const Thumbnails = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  ${min.desktop} {
+    grid-column: 1 / 2;
+  }
+`;
+
+export const Thumbnail = styled.img`
+  height: 5rem;
+  margin: 0 1rem 1rem 0;
+  ${PointerStyles}
+  &:hover {
+    outline: 10px solid ${YELLOW};
+    outline-offset: -10px;
+  }
+  ${min.tablet} {
+    height: 7.125rem;
+  }
+  ${min.desktop} {
+    height: 8.75rem;
+  }
+`;

--- a/src/components/Layout/styled.js
+++ b/src/components/Layout/styled.js
@@ -1,16 +1,14 @@
 import { createGlobalStyle } from 'styled-components';
-import { BLACK, CREAM } from '../../styles/styles';
-import Cursor from '../../images/cursor.svg';
-import CursorPointer from '../../images/cursor-pointer.svg';
+import { BLACK, CREAM, CursorStyles, PointerStyles } from '../../styles/styles';
 
 export const GlobalStyle = createGlobalStyle`
   body {
     color: ${CREAM};
     background-color: ${BLACK};
     margin: 0;
-    cursor: url(${Cursor}) 20 20, auto;
+    ${CursorStyles}
   }
   a, button {
-    cursor: url(${CursorPointer}) 20 20, pointer;
+    ${PointerStyles}
   }
 `;

--- a/src/pages/projects/{PrismicProject.uid}.js
+++ b/src/pages/projects/{PrismicProject.uid}.js
@@ -20,14 +20,14 @@ const ProjectPage = ({ data }) => {
             document: {
               uid,
               data: {
-                embed: { thumbnail_url: thumbnail },
+                thumbnail: { url: thumbnailUrl, alt },
               },
             },
           },
         } = work;
         return (
-          <Link to={`/works/${uid}`}>
-            <img src={thumbnail} />
+          <Link to={`/works/${uid}`} key={uid}>
+            <img src={thumbnailUrl} alt={alt} />
           </Link>
         );
       })}
@@ -51,8 +51,27 @@ export const query = graphql`
               ... on PrismicVideo {
                 uid
                 data {
-                  embed {
-                    thumbnail_url
+                  thumbnail {
+                    url
+                    alt
+                  }
+                }
+              }
+              ... on PrismicArticle {
+                uid
+                data {
+                  thumbnail {
+                    url
+                    alt
+                  }
+                }
+              }
+              ... on PrismicGallery {
+                uid
+                data {
+                  thumbnail {
+                    url
+                    alt
                   }
                 }
               }

--- a/src/pages/works/{PrismicGallery.uid}.js
+++ b/src/pages/works/{PrismicGallery.uid}.js
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { graphql } from 'gatsby';
+import Layout from '../../components/Layout';
+import Gallery from '../../components/Gallery';
+
+const GalleryPage = ({ data }) => {
+  if (!data) return null;
+  const {
+    prismicGallery: {
+      data: {
+        title: { text: title },
+        project: { document: project },
+        artist_name: { text: artistName },
+        date_published: datePublished,
+        description: { text: description },
+        images,
+      },
+    },
+  } = data;
+
+  return (
+    <Layout>
+      <Gallery
+        title={title}
+        project={project}
+        artistName={artistName}
+        datePublished={datePublished}
+        description={description}
+        images={images}
+      />
+    </Layout>
+  );
+};
+
+export const query = graphql`
+  query GalleryPageQuery($uid: String) {
+    prismicGallery(uid: { eq: $uid }) {
+      data {
+        title {
+          text
+        }
+        artist_name {
+          text
+        }
+        date_published(formatString: "MMMM DD, YYYY")
+        description {
+          text
+        }
+        images {
+          image {
+            url
+            alt
+          }
+        }
+        project {
+          document {
+            ... on PrismicProject {
+              uid
+              data {
+                name {
+                  text
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default GalleryPage;

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1,7 +1,9 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import './styles.css';
 import { min } from './breakpoints';
 import { Link } from 'gatsby';
+import Cursor from '../images/cursor.svg';
+import CursorPointer from '../images/cursor-pointer.svg';
 
 // Colors
 export const YELLOW = '#ECF955';
@@ -76,4 +78,12 @@ export const A = styled.a`
 
 export const StyledLink = styled(Link)`
   ${linkStyles}
+`;
+
+export const CursorStyles = css`
+  cursor: url(${Cursor}) 20 20, auto;
+`;
+
+export const PointerStyles = css`
+  cursor: url(${CursorPointer}) 20 20, pointer;
 `;


### PR DESCRIPTION
## Notes
- single gallery page that follows the same format as video and article pages
- you can see the gallery example at /works/sample-gallery or by clicking on the first item in /projects/sample-project
- I put `CursorStyles` and `PointerStyles` in our `styles.js` file because I noticed we're using it for a lot of elements
- I made an `<ArrowControls>` component that cycles through indices of a list of items, it does the job for the gallery page and I think it will be useful for the carousels on the homepage and the single project page, but let me know if there's a better solution
## Figma
Desktop:
<img width="648" alt="Screen Shot 2022-05-06 at 3 07 59 PM" src="https://user-images.githubusercontent.com/52389456/167202377-7b9b4ef2-2760-4669-970b-6784830a560c.png">

Tablet:
<img width="374" alt="Screen Shot 2022-05-06 at 3 08 11 PM" src="https://user-images.githubusercontent.com/52389456/167202400-f46a9e50-a8f2-4467-9761-9d238adf1127.png">

Mobile:
<img width="186" alt="Screen Shot 2022-05-06 at 3 08 23 PM" src="https://user-images.githubusercontent.com/52389456/167202413-9e06d7e1-4885-49c7-bd93-1c39c96ec99d.png">

