### PR TITLE
explore view section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-feather": "^2.0.9",
+        "react-grid-gallery": "^0.5.5",
         "react-multi-carousel": "^2.8.0",
+        "react-responsive-masonry": "^2.1.4",
         "styled-components": "^5.3.3"
       }
     },
@@ -3851,6 +3853,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aphrodite": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/aphrodite/-/aphrodite-0.5.0.tgz",
+      "integrity": "sha512-bPcR/68OdLg+16XDYAaKnlGJufxrbOw86ucElS7qHm7Y6ZNvMT/D/VDEEfodjFgfyRyoTeKmSaikULG92kSYvQ==",
+      "dependencies": {
+        "asap": "^2.0.3",
+        "inline-style-prefixer": "^2.0.0"
+      }
+    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -4043,6 +4054,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -4525,6 +4541,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "node_modules/bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -6340,6 +6361,14 @@
         "utila": "~0.4"
       }
     },
+    "node_modules/dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/dom-serializer": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
@@ -7554,6 +7583,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "node_modules/exif-parser": {
       "version": "0.1.12",
@@ -10201,6 +10235,11 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -10365,6 +10404,18 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
+      "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
+      "dependencies": {
+        "bowser": "^1.0.0",
+        "hyphenate-style-name": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/inquirer": {
       "version": "7.3.3",
@@ -14241,6 +14292,85 @@
         "react": "^16.8.6 || ^17"
       }
     },
+    "node_modules/react-grid-gallery": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/react-grid-gallery/-/react-grid-gallery-0.5.5.tgz",
+      "integrity": "sha512-DkKg2/Am+VZPDG39fazelTcsZSQrfM/YllnIcWToyUEfOZcrzHxUoqCziCkuTPmCuMbHnrjidBFuDbAFgvSnvQ==",
+      "dependencies": {
+        "prop-types": "^15.5.8",
+        "react-images": "^0.5.16"
+      }
+    },
+    "node_modules/react-grid-gallery/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-grid-gallery/node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
+    "node_modules/react-grid-gallery/node_modules/react-images": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/react-images/-/react-images-0.5.19.tgz",
+      "integrity": "sha512-B3d4W1uFJj+m17K8S65iAyEJShKGBjPk7n7N1YsPiAydEm8mIq9a6CoeQFMY1d7N2QMs6FBCjT9vELyc5jP5JA==",
+      "deprecated": "This beta version is no longer supported. Please update to 1.1.0-beta.4",
+      "dependencies": {
+        "aphrodite": "^0.5.0",
+        "prop-types": "^15.6.0",
+        "react-scrolllock": "^2.0.1",
+        "react-transition-group": "2"
+      },
+      "peerDependencies": {
+        "react": "^15.0 || ^16.0",
+        "react-dom": "^15.0 || ^16.0"
+      }
+    },
+    "node_modules/react-grid-gallery/node_modules/react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "dependencies": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
+      }
+    },
+    "node_modules/react-grid-gallery/node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -14270,6 +14400,63 @@
       "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-scrolllock": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-2.0.7.tgz",
+      "integrity": "sha512-Gzpu8+ulxdYcybAgJOFTXc70xs7SBZDQbZNpKzchZUgLCJKjz6lrgESx6LHHZgfELx1xYL4yHu3kYQGQPFas/g==",
+      "dependencies": {
+        "exenv": "^1.2.2",
+        "react-prop-toggle": "^1.0.2"
+      }
+    },
+    "node_modules/react-scrolllock/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-scrolllock/node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
+    "node_modules/react-scrolllock/node_modules/react-prop-toggle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-prop-toggle/-/react-prop-toggle-1.0.2.tgz",
+      "integrity": "sha512-JmerjAXs7qJ959+d0Ygt7Cb2+4fG+n3I2VXO6JO0AcAY1vkRN/JpZKAN67CMXY889xEJcfylmMPhzvf6nWO68Q==",
+      "peerDependencies": {
+        "react": "^16.3.0",
+        "react-dom": "^16.3.0"
+      }
+    },
+    "node_modules/react-scrolllock/node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/read": {
@@ -20300,6 +20487,15 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aphrodite": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/aphrodite/-/aphrodite-0.5.0.tgz",
+      "integrity": "sha512-bPcR/68OdLg+16XDYAaKnlGJufxrbOw86ucElS7qHm7Y6ZNvMT/D/VDEEfodjFgfyRyoTeKmSaikULG92kSYvQ==",
+      "requires": {
+        "asap": "^2.0.3",
+        "inline-style-prefixer": "^2.0.0"
+      }
+    },
     "append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -20441,6 +20637,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -20820,6 +21021,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
     },
     "boxen": {
       "version": "5.1.2",
@@ -22218,6 +22424,14 @@
         "utila": "~0.4"
       }
     },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "dom-serializer": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
@@ -23103,6 +23317,11 @@
           }
         }
       }
+    },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "exif-parser": {
       "version": "0.1.12",
@@ -25163,6 +25382,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -25267,6 +25491,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+    },
+    "inline-style-prefixer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
+      "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
+      "requires": {
+        "bowser": "^1.0.0",
+        "hyphenate-style-name": "^1.0.1"
+      }
     },
     "inquirer": {
       "version": "7.3.3",
@@ -28114,6 +28347,72 @@
         "prop-types": "^15.7.2"
       }
     },
+    "react-grid-gallery": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/react-grid-gallery/-/react-grid-gallery-0.5.5.tgz",
+      "integrity": "sha512-DkKg2/Am+VZPDG39fazelTcsZSQrfM/YllnIcWToyUEfOZcrzHxUoqCziCkuTPmCuMbHnrjidBFuDbAFgvSnvQ==",
+      "requires": {
+        "prop-types": "^15.5.8",
+        "react-images": "^0.5.16"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "react-images": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/react-images/-/react-images-0.5.19.tgz",
+          "integrity": "sha512-B3d4W1uFJj+m17K8S65iAyEJShKGBjPk7n7N1YsPiAydEm8mIq9a6CoeQFMY1d7N2QMs6FBCjT9vELyc5jP5JA==",
+          "requires": {
+            "aphrodite": "^0.5.0",
+            "prop-types": "^15.6.0",
+            "react-scrolllock": "^2.0.1",
+            "react-transition-group": "2"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -28138,6 +28437,62 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
       "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ=="
+    },
+    "react-responsive-masonry": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/react-responsive-masonry/-/react-responsive-masonry-2.1.4.tgz",
+      "integrity": "sha512-Neqkc6gM7F5d+nBvDSlKQmQOjdWNabLT2EXpVvpJb6oD8lD3hRujd8IDd1UViQR++SSTkhLcsC3Ru7hc6XjT5A==",
+      "requires": {}
+    },
+    "react-scrolllock": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-2.0.7.tgz",
+      "integrity": "sha512-Gzpu8+ulxdYcybAgJOFTXc70xs7SBZDQbZNpKzchZUgLCJKjz6lrgESx6LHHZgfELx1xYL4yHu3kYQGQPFas/g==",
+      "requires": {
+        "exenv": "^1.2.2",
+        "react-prop-toggle": "^1.0.2"
+      },
+      "dependencies": {
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "react-prop-toggle": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/react-prop-toggle/-/react-prop-toggle-1.0.2.tgz",
+          "integrity": "sha512-JmerjAXs7qJ959+d0Ygt7Cb2+4fG+n3I2VXO6JO0AcAY1vkRN/JpZKAN67CMXY889xEJcfylmMPhzvf6nWO68Q==",
+          "requires": {}
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
     },
     "read": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-feather": "^2.0.9",
+    "react-grid-gallery": "^0.5.5",
     "react-multi-carousel": "^2.8.0",
+    "react-responsive-masonry": "^2.1.4",
     "styled-components": "^5.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react-feather": "^2.0.9",
     "react-grid-gallery": "^0.5.5",
     "react-multi-carousel": "^2.8.0",
-    "react-responsive-masonry": "^2.1.4",
     "styled-components": "^5.3.3"
   }
 }

--- a/src/components/ExploreCarousel/index.js
+++ b/src/components/ExploreCarousel/index.js
@@ -14,6 +14,7 @@ import {
   ItemContainer,
 } from "./styled";
 import Carousel from "react-multi-carousel";
+import ExploreGallery from "../ExploreGallery";
 import "react-multi-carousel/lib/styles.css";
 
 const ExploreCarousel = ({ section }) => {
@@ -123,12 +124,16 @@ const ExploreCarousel = ({ section }) => {
 
   return (
     <FlexContainer>
-      {sectionuid === "read" || sectionuid === "watch" ? (
-        <div>
-          <H2 bold>{title.text}</H2>
-          {sectionuid === "read" ? <StackedCarousel /> : <SingleCarousel />}
-        </div>
-      ) : null}
+      <div>
+        <H2 bold>{title.text}</H2>
+        {sectionuid === "read" ? (
+          <StackedCarousel />
+        ) : sectionuid === "watch" ? (
+          <SingleCarousel />
+        ) : (
+          <ExploreGallery works={works} />
+        )}
+      </div>
     </FlexContainer>
   );
 };

--- a/src/components/ExploreGallery/index.js
+++ b/src/components/ExploreGallery/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import Gallery from "react-grid-gallery";
-import { ViewContainer } from "./styled";
+import { ViewContainer, StyledH3 } from "./styled";
 import { navigate } from "gatsby";
 
 const ExploreGallery = ({ works }) => {
@@ -8,30 +8,30 @@ const ExploreGallery = ({ works }) => {
 
   useEffect(() => {
     const galleryImages = [];
-    works.map((work) => {
+    works.forEach((work) => {
       const {
         work: {
           document: {
             uid,
-            data: { images },
+            data: { images, title },
           },
         },
       } = work;
-      images.map((image, i) => {
-        if (i < 5) {
-          let img = {
-            src: image.image.url,
-            thumbnail: image.image.url,
-            thumbnailHeight: image.image.dimensions.height,
-            thumbnailWidth: image.image.dimensions.width,
-            uid: work.work.document.uid,
-          };
-          galleryImages.push(img);
-        }
-        return null;
+      images.forEach((image) => {
+        let img = {
+          src: image.image.url,
+          thumbnail: image.image.url,
+          thumbnailHeight: image.image.dimensions.height,
+          thumbnailWidth: image.image.dimensions.width,
+          uid: work.work.document.uid,
+          customOverlay: (
+            <StyledH3>{work.work.document.data.title.text}</StyledH3>
+          ),
+        };
+        galleryImages.push(img);
       });
-      return null;
     });
+
     const shuffledImages = galleryImages.sort((a, b) => 0.5 - Math.random()); //shuffle images
     setImageList(shuffledImages);
   }, []);
@@ -52,7 +52,7 @@ const ExploreGallery = ({ works }) => {
         images={imageList}
         enableImageSelection={false}
         enableLightbox={false}
-        rowHeight={350}
+        rowHeight={300}
         margin={5}
         maxRows={3}
         thumbnailStyle={imageStyle}

--- a/src/components/ExploreGallery/index.js
+++ b/src/components/ExploreGallery/index.js
@@ -32,7 +32,7 @@ const ExploreGallery = ({ works }) => {
       });
       return null;
     });
-    const shuffledImages = galleryImages.sort((a, b) => 0.5 - Math.random());
+    const shuffledImages = galleryImages.sort((a, b) => 0.5 - Math.random()); //shuffle images
     setImageList(shuffledImages);
   }, []);
 

--- a/src/components/ExploreGallery/index.js
+++ b/src/components/ExploreGallery/index.js
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from "react";
+import Gallery from "react-grid-gallery";
+import { ViewContainer } from "./styled";
+import { navigate } from "gatsby";
+
+const ExploreGallery = ({ works }) => {
+  const [imageList, setImageList] = useState([]);
+
+  useEffect(() => {
+    const galleryImages = [];
+    works.map((work) => {
+      const {
+        work: {
+          document: {
+            uid,
+            data: { images },
+          },
+        },
+      } = work;
+      images.map((image, i) => {
+        if (i < 5) {
+          let img = {
+            src: image.image.url,
+            thumbnail: image.image.url,
+            thumbnailHeight: image.image.dimensions.height,
+            thumbnailWidth: image.image.dimensions.width,
+            uid: work.work.document.uid,
+          };
+          galleryImages.push(img);
+        }
+        return null;
+      });
+      return null;
+    });
+    const shuffledImages = galleryImages.sort((a, b) => 0.5 - Math.random());
+    setImageList(shuffledImages);
+  }, []);
+
+  function imageStyle() {
+    return {
+      height: "100%",
+    };
+  }
+
+  function redirectGallery(index) {
+    return navigate("/works/" + imageList[index].uid);
+  }
+
+  return (
+    <ViewContainer>
+      <Gallery
+        images={imageList}
+        enableImageSelection={false}
+        enableLightbox={false}
+        rowHeight={350}
+        margin={5}
+        maxRows={3}
+        thumbnailStyle={imageStyle}
+        onClickThumbnail={redirectGallery}
+      />
+    </ViewContainer>
+  );
+};
+
+export default ExploreGallery;

--- a/src/components/ExploreGallery/styled.js
+++ b/src/components/ExploreGallery/styled.js
@@ -1,7 +1,15 @@
 import styled from "styled-components";
 import Cursor from "../../images/cursor-pointer.svg";
+import { H3 } from "../../styles/styles";
 
 export const ViewContainer = styled.div`
   margin-bottom: 6rem;
+  height: 900;
+  overflow: hidden;
   cursor: url(${Cursor}) 20 20, pointer;
+`;
+
+export const StyledH3 = styled(H3)`
+  margin-top: 250px;
+  margin-left: 10px;
 `;

--- a/src/components/ExploreGallery/styled.js
+++ b/src/components/ExploreGallery/styled.js
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+import Cursor from "../../images/cursor-pointer.svg";
+
+export const ViewContainer = styled.div`
+  margin-bottom: 6rem;
+  cursor: url(${Cursor}) 20 20, pointer;
+`;

--- a/src/pages/explore.js
+++ b/src/pages/explore.js
@@ -58,6 +58,16 @@ const Explore = () => {
                               title {
                                 text
                               }
+                              images {
+                                image {
+                                  url
+                                  alt
+                                  dimensions {
+                                    height
+                                    width
+                                  }
+                                }
+                              }
                             }
                           }
                         }


### PR DESCRIPTION
For this section I used this library 
https://www.npmjs.com/package/react-grid-gallery 
in retrospect it might have been a bit of overkill, but it is very clean and responsive.

The way I currently have it set up is it takes 5 photos from each gallery linked in the view section and randomly shuffles them so that not all the images from the same gallery are next to each other, then it displays as many of the images as will fit in three rows of the grid. Let me know if the shuffling doesn't make sense for what we want. Clicking an image will link back to the gallery it is from. (repeat images in the preview are because I linked the same gallery three times).

Alsoo in figma some of the images have text that says piece name, I currently haven't put that in because the images don't have titles, unless thats supposed to be the gallery name for each photo? For now I just left it out

<img width="458" alt="Screen Shot 2022-05-20 at 3 00 12 PM" src="https://user-images.githubusercontent.com/72950143/169594706-a25b1e08-4715-4696-81b8-bdf15ff314ff.png">
<img width="266" alt="Screen Shot 2022-05-20 at 3 00 29 PM" src="https://user-images.githubusercontent.com/72950143/169594725-5c30efe9-adc8-44b2-9313-c724aee4b24d.png">
<img width="297" alt="Screen Shot 2022-05-20 at 3 00 40 PM" src="https://user-images.githubusercontent.com/72950143/169594752-93dfa38a-bf9c-4e27-888e-4a5e42537fd7.png">
 